### PR TITLE
Unit tests for service invocation binding expressions

### DIFF
--- a/src/Dapr.AzureFunctions.Extension/Services/DaprServiceClient.cs
+++ b/src/Dapr.AzureFunctions.Extension/Services/DaprServiceClient.cs
@@ -49,7 +49,7 @@ namespace Dapr.AzureFunctions.Extension
                 string errorCode = string.Empty;
                 string errorMessage = string.Empty;
 
-                if (response.Content != null)
+                if (response.Content != null && response.Content.Headers.ContentLength != 0)
                 {
                     JObject daprError;
 

--- a/src/Dapr.AzureFunctions.Extension/Triggers/DaprTriggerBindingBase.cs
+++ b/src/Dapr.AzureFunctions.Extension/Triggers/DaprTriggerBindingBase.cs
@@ -53,12 +53,20 @@ namespace Dapr.AzureFunctions.Extension
             Stream inputStream = requestContext.Request.Body;
             Type destinationType = this.parameter.ParameterType;
 
-            var bindingData = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            var bindingData = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
 
-            object convertedValue;
-            if (inputStream == null)
+            object? convertedValue;
+            if (inputStream == null || requestContext.Request.ContentLength == 0)
             {
-                convertedValue = this.parameter.DefaultValue;
+                // Assigns null for reference types or the default value for value types
+                if (this.parameter.ParameterType.IsValueType)
+                {
+                    convertedValue = Activator.CreateInstance(this.parameter.ParameterType);
+                }
+                else
+                {
+                    convertedValue = null;
+                }
             }
             else if (destinationType.IsAssignableFrom(inputStream.GetType()))
             {

--- a/test/DaprExtensionTests/DaprTestBase.cs
+++ b/test/DaprExtensionTests/DaprTestBase.cs
@@ -147,6 +147,9 @@ namespace DaprExtensionTests
         internal JToken? FetchSavedStateForUnitTesting(string stateStore, string key) 
             => this.daprRuntime.FetchSavedStateForUnitTesting(stateStore, key);
 
+        internal void SaveStateForUnitTetsing(string storeName, string key, JToken value)
+            => this.daprRuntime.SaveStateForUnitTesting(storeName, key, value);
+
         Task IAsyncLifetime.InitializeAsync()
         {
             return Task.WhenAll(


### PR DESCRIPTION
Resolves #52 

We were missing tests that validate expression binding when using the service invocation trigger binding. This PR adds testing for simple expressions - e.g. `"{keyName}"` - and object expressions - e.g. `"{input.keyName}"`. The feature always worked but wasn't being tested.

This also fixes Dapr emulator issues and issues related to empty HTTP payloads, which I discovered while writing these tests.