### PR TITLE
Updated to latest NuGet Dapr Bindings

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -27,7 +27,7 @@ The following will get you started with a Function app that leverages the Dapr e
 While this extension is in preview it is not included in the default extension bundle for functions.  We can still include it, but will need to manually install it into the project, and opt-out to using the default extensions.  
 
 1. Open the `host.json` file from the root of the project and remove the `extensionBundle` property and values (if they exist).  Save the file.
-1. Run `func extensions install -p Dapr.AzureFunctions.Extension -v 0.8.0-preview01`
+1. Run `func extensions install -p Dapr.AzureFunctions.Extension -v 0.10.0-preview01`. Be sure to use the latest version as published on [NuGet](https://www.nuget.org/packages/Dapr.AzureFunctions.Extension).
 
 You can validate the extension installed successfully by running the function.  Run `func start` and validate the app loads and the startup contains the logs
 


### PR DESCRIPTION
I updated the command to get the version 0.10.0-preview01 of Dapr Azure Function extension in NuGet and added a disclaimer to always look for the newest version of it.
The sample wasn't working with the version 0.8.0-preview01 of the NuGet extension. 